### PR TITLE
Bugfix: Anchor tags on slides sometimes not clickable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tucows/donejs-carousel-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A carousel plugin for donejs",
   "homepage": "https://github.com/tucows/donejs-carousel-plugin",
   "repository": {

--- a/src/demo/demo.stache
+++ b/src/demo/demo.stache
@@ -25,7 +25,7 @@
 			<div class="block slide {{#is ../activeSlideIndex scope.index}} active {{/is}}" tabindex="{{#is ../activeSlideIndex scope.index}} 0 {{else}} -1 {{/is}}" style="background-color: {{./backgroundColor}}">
 				
 				<div class="slideContent">
-					<h1>{{./title}}</h1>
+					<h1>{{{./title}}}</h1>
 					<p>{{{./content1}}}</p>
 					<p>{{{./content2}}}</p>
 				</div>

--- a/src/donejs-carousel-plugin.less
+++ b/src/donejs-carousel-plugin.less
@@ -94,14 +94,15 @@ tucows-donejs-carousel {
 			display: grid;
 		}
 		.slide {
-	    	grid-column: 1;
-	    	grid-row: 1;
-	    	opacity: 0;
+			grid-column: 1;
+			grid-row: 1;
+			opacity: 0;
 
-	    	&.active {
-	    	        opacity: 1;
-	    	}
-	    }
+			&.active {
+				opacity: 1;
+				z-index: 100;
+			}
+		}
 	}
 
 	@media screen and (min-width: 1024px) {

--- a/src/test-and-demo-constants.js
+++ b/src/test-and-demo-constants.js
@@ -1,20 +1,20 @@
 export const slides = [
 	{
-		title: "*Insistently* Bow ties are cool! Come on Amy, I'm a normal bloke, tell me what normal blokes do!",
+		title: "<a href=#overlap1>*Insistently*</a>Bow ties are cool! Come on Amy, I'm a normal bloke, tell me what normal blokes do!",
 		content1: `I hate yogurt. It's just stuff with bits in. I am the Doctor, and you are the Daleks! I'm nobody's taxi service; I'm not gonna be there to catch you every time you feel like jumping out of a spaceship.`,
-		content2: `<a href=#>Just a link to nowhere!</a><strong>I'm nobody's taxi service; I'm not gonna be there to catch you every time you feel like jumping out of a spaceship.</strong> <em> You know how I sometimes have really brilliant ideas?</em> I am the last of my species, and I know how that weighs on the heart so don't lie to me!`,
+		content2: `<a href=#linkone>Just a link to nowhere!</a><strong>I'm nobody's taxi service; I'm not gonna be there to catch you every time you feel like jumping out of a spaceship.</strong> <em> You know how I sometimes have really brilliant ideas?</em> I am the last of my species, and I know how that weighs on the heart so don't lie to me!`,
 		backgroundColor: '#23f2a3'
 	},
 	{
-		title: "They're not aliens, they're Earth…liens!",
-		content1: `<a href=#>Just a link to nowhere!</a>All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong? Did I mention we have comfy chairs?`,
+		title: "<a href=#overlap2>They're not aliens</a>, they're Earth…liens!",
+		content1: `<a href=#linktwo>Just a link to nowhere!</a>All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong? All I've got to do is pass as an ordinary human being. Simple. What could possibly go wrong? Did I mention we have comfy chairs?`,
 		content2: `You've swallowed a planet! I am the last of my species, and I know how that weighs on the heart so don't lie to me! <strong> I am the Doctor, and you are the Daleks!</strong> <em> *Insistently* Bow ties are cool!</em> Come on Amy, I'm a normal bloke, tell me what normal blokes do!`,
 		backgroundColor: 'orange'
 	},
 	{
 		title: 'Stop talking, brain thinking. Hush.',
 		content1: `You hate me; you want to kill me! Well, go on! Kill me! KILL ME! I'm the Doctor, I'm worse than everyone's aunt. *catches himself* And that is not how I'm introducing myself. You hit me with a cricket bat.`,
-		content2: `Father Christmas. Santa Claus. Or as I've always known him: Jeff. I hate yogurt. It's just stuff with bits in. <strong> All I've got to do is pass as an ordinary human being.</strong> <em> Simple.</em> What could possibly go wrong?<a href=#>Just a link to nowhere!</a>`,
+		content2: `Father Christmas. Santa Claus. Or as I've always known him: Jeff. I hate yogurt. It's just stuff with bits in. <strong> All I've got to do is pass as an ordinary human being.</strong> <em> Simple.</em> What could possibly go wrong?<a href=#linkethree>Just a link to nowhere!</a>`,
 		backgroundColor: 'lightblue'
 	}
 ];


### PR DESCRIPTION
### The problem

Only anchor tags on the last slide are clickable. This obviously is a major problem but leads to frustration especially when links are stacked one atop the other as is the case with the current carousel, since the user thinks the click will work but in fact it directs him/her to the URI of the last slide.

### The solution

Add `z-index: 100` to the active slide, and make all other slides `z-index: 0`. This ensures that the slide at the foreground will always properly handle the click event on anchor tags.

### JIRA
https://jira.tucows.net/browse/TING-564?orderby=affectedVersion+ASC%2C+assignee+ASC%2C+priority+DESC%2C+updated+DESC

Refs TING-564