### PR TITLE
Revert "Revert "TING-533 Write Functional Tests""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+dist: xenial
 language: node_js
 node_js: lts/*
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  - # start your web application and listen on `localhost`
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+chrome: beta

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tucows/donejs-carousel-plugin",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "description": "A carousel plugin for donejs",
   "homepage": "https://github.com/tucows/donejs-carousel-plugin",
   "repository": {
@@ -68,7 +68,7 @@
   "dependencies": {
     "can-component": "^3.0.7",
     "can-define": "^1.5.7",
-    "can-stache": "^3.15.1",
+    "can-stache": "^3.14.22",
     "can-view-autorender": "^3.0.4",
     "cssify": "^0.6.0",
     "steal-css": "^1.2.5",
@@ -95,6 +95,6 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Tucows/donejs-carousel-plugin/issues"
+    "url": "https://github.com/tucows/donejs-carousel-plugin/issues"
   }
 }

--- a/src/demo/demo.stache
+++ b/src/demo/demo.stache
@@ -1,5 +1,7 @@
 <div class="information">
-	<h2>{{./carouselName}}</h2>
+	{{#if ./carouselName}}
+		<h2>{{./carouselName}}</h2>
+	{{/if}}
 	<pre>
 	{
 		slides: slides,

--- a/src/donejs-carousel-plugin.stache
+++ b/src/donejs-carousel-plugin.stache
@@ -106,7 +106,7 @@
 {{else}} {{! When server side rendering}}
 	{{>simpleCarousel}}
 
-	{{#if ./isLengthOneOrLess(./slides.length)}}
+	{{#is ./slides.length 1}}
          {{! don't show dots }}
     {{else}}
     

--- a/testee.json
+++ b/testee.json
@@ -8,13 +8,13 @@
                 "--headless",
                 "--disable-gpu",
                 "--disable-extensions",
-								"--no-sandbox",
+                "--no-sandbox",
                 "--remote-debugging-port=9222"
             ]
         }
     ],
-	"coverage": {
-		"dir": "coverage",
-		"ignore": ["node_modules"]
-	}
+    "coverage": {
+        "dir": "coverage",
+        "ignore": ["node_modules"]
+    }
 }


### PR DESCRIPTION
Reverts tucows/donejs-carousel-plugin#14

### Description ###

This PR provides functional tests for the carousel plugin

It specifically tests one of the TEST Cases outlined by Vlad in this JIRA ticket: https://jira.tucows.net/browse/TING-533

5) Verify the transition is set to 1000ms (or whatever the current appropriate number was 0.4s before) (https://github.com/tucows/donejs-carousel-plugin/pull/15)

The remaining are covered by another PR for `ting-node`: https://github.com/tucowsinc/ting-node/pull/293.

1) Ensure there is a minimum of one default tout (https://github.com/tucowsinc/ting-node/pull/293)
2) Provide failsafe message in case carousel component does not load(lets say browser does not support) (https://github.com/tucowsinc/ting-node/pull/293)
3) Check 11 parameters are being passed from backend API:  name, heading_text, subheading_text, cta_text, url, graphic, alt_text, background_color, heading_text_color, subheading_text_color and cta_text_color (https://github.com/tucowsinc/ting-node/pull/293)
4) Verify console component loads within page header (https://github.com/tucowsinc/ting-node/pull/293)

### Also fixes
1.  Wrapped objects set directly onto `value` in the view model into a function (see https://github.com/canjs/can-define/issues/148)