### PR TITLE
Feature/no slides scenario

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tucows/donejs-carousel-plugin",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/donejs-carousel-plugin.less
+++ b/src/donejs-carousel-plugin.less
@@ -22,7 +22,6 @@ tucows-donejs-carousel {
 		top: 45%;
 
 		svg {
-			fill: #00aaee;
 			height: 40px;
 			width: 40px;
 		}

--- a/src/donejs-carousel-plugin.stache
+++ b/src/donejs-carousel-plugin.stache
@@ -28,98 +28,103 @@
 
 {{! partial components end }}
 
-{{#if ./isDesktopBrowser}}
-	
-	{{#is ./slides.length 1}}
+{{#if ./slides.length}}
 
-		{{>simpleCarousel}}
-	
-	{{else}}
+	{{#if ./isDesktopBrowser}}
+		
+		{{#is ./slides.length 1}}
 
-		{{! Note: We prevent default on the dragstart event (and use mouse events instead) to prevent the creation of the 'ghost image' on drag}}
-		{{! Note: The event handlers are on div.carousel because attaching them to div.slideTrack is unreliable (result of .slideTrack being translated)}}
-		<div class="carousel 
-			{{#if ./carouselOptions.extraClass}} 
-				{{./carouselOptions.extraClass}} 
-			{{/if}}
-			{{#is ./carouselOptions.transition 'dissolve'}} 
-				dissolve-transition
-			{{/is}}
-			{{#if ./carouselOptions.breakOnDesktop}}
-				breakOnDesktop
-			{{/if}}"
+			{{>simpleCarousel}}
+		
+		{{else}}
 
-			on:dragstart="./preventDefault(scope.event)"
+			{{! Note: We prevent default on the dragstart event (and use mouse events instead) to prevent the creation of the 'ghost image' on drag}}
+			{{! Note: The event handlers are on div.carousel because attaching them to div.slideTrack is unreliable (result of .slideTrack being translated)}}
+			<div class="carousel 
+				{{#if ./carouselOptions.extraClass}} 
+					{{./carouselOptions.extraClass}} 
+				{{/if}}
+				{{#is ./carouselOptions.transition 'dissolve'}} 
+					dissolve-transition
+				{{/is}}
+				{{#if ./carouselOptions.breakOnDesktop}}
+					breakOnDesktop
+				{{/if}}"
 
-			on:mousedown="./swipeHandler(scope.event, 'start')"
-			on:mouseup="./swipeHandler(scope.event, 'end')"
-			on:mouseleave="./swipeHandler(scope.event, 'end')"
-			on:mousemove="./swipeHandler(scope.event, 'move')"
+				on:dragstart="./preventDefault(scope.event)"
 
-			on:touchstart="./swipeHandler(scope.event, 'start')"
-			on:touchend="./swipeHandler(scope.event, 'end')"
-			on:touchcancel="./swipeHandler(scope.event, 'end')"
-			on:touchmove="./swipeHandler(scope.event, 'move')"
+				on:mousedown="./swipeHandler(scope.event, 'start')"
+				on:mouseup="./swipeHandler(scope.event, 'end')"
+				on:mouseleave="./swipeHandler(scope.event, 'end')"
+				on:mousemove="./swipeHandler(scope.event, 'move')"
 
-			on:keydown="./arrowClickHandler('keyboard', scope.event)"
-		> 
-			<div class="slideTrack">
-				
-				<content />
+				on:touchstart="./swipeHandler(scope.event, 'start')"
+				on:touchend="./swipeHandler(scope.event, 'end')"
+				on:touchcancel="./swipeHandler(scope.event, 'end')"
+				on:touchmove="./swipeHandler(scope.event, 'move')"
+
+				on:keydown="./arrowClickHandler('keyboard', scope.event)"
+			> 
+				<div class="slideTrack">
+					
+					<content />
+
+				</div>
+
+				{{#if ./carouselOptions.navArrows}}
+					<div class="navArrows">
+
+						<a class="leftArrow arrow" 
+							on:click="./arrowClickHandler('left', scope.event)"
+						>
+							<svg role="img" class="iconSvg" title="left nav arrow">
+								<use href="{{./carouselOptions.navArrows.leftSvgUrl}}"></use>
+							</svg>
+						</a>
+						
+						<a class="rightArrow arrow" 
+							on:click="./arrowClickHandler('right', scope.event)"
+						>
+							<svg role="img" class="iconSvg" title="right nav arrow">
+								<use href="{{./carouselOptions.navArrows.rightSvgUrl}}"></use>
+							</svg>
+						</a>
+					</div>
+				{{/if}}
 
 			</div>
+			<div class="navDots
+				{{#if ./carouselOptions.breakOnDesktop}}
+					breakOnDesktop
+				{{/if}}"
+			>
+				{{#each ./slides}}
+					<div class="dot {{#is ../activeSlideIndex scope.index}}active{{/is}}" on:click="../dotClickHandler(scope.index)">
+						{{>navDotsSVG}}
+					</div>
+				{{/each}}
+			</div>
+		{{/is}}
+	{{else}} {{! When server side rendering}}
+		{{>simpleCarousel}}
 
-			{{#if ./carouselOptions.navArrows}}
-				<div class="navArrows">
-
-					<a class="leftArrow arrow" 
-						on:click="./arrowClickHandler('left', scope.event)"
-					>
-						<svg role="img" class="iconSvg" title="left nav arrow">
-							<use href="{{./carouselOptions.navArrows.leftSvgUrl}}"></use>
-						</svg>
-					</a>
-					
-					<a class="rightArrow arrow" 
-						on:click="./arrowClickHandler('right', scope.event)"
-					>
-						<svg role="img" class="iconSvg" title="right nav arrow">
-							<use href="{{./carouselOptions.navArrows.rightSvgUrl}}"></use>
-						</svg>
-					</a>
-				</div>
-			{{/if}}
-
-		</div>
-		<div class="navDots
-			{{#if ./carouselOptions.breakOnDesktop}}
-				breakOnDesktop
-			{{/if}}"
-		>
-			{{#each ./slides}}
-				<div class="dot {{#is ../activeSlideIndex scope.index}}active{{/is}}" on:click="../dotClickHandler(scope.index)">
-					{{>navDotsSVG}}
-				</div>
-			{{/each}}
-		</div>
-	{{/is}}
-{{else}} {{! When server side rendering}}
-	{{>simpleCarousel}}
-
-	{{#is ./slides.length 1}}
-         {{! don't show dots }}
-    {{else}}
-    
-        <div class="navDots
-            {{#if ./carouselOptions.breakOnDesktop}}
-                breakOnDesktop
-            {{/if}}"
-        >
-            {{#each ./slides}}
-                <div class="dot {{#is scope.index 0}}active{{/is}}">
-                    {{>navDotsSVG}}
-                </div>
-            {{/each}}
-        </div>
-    {{/if}}
+		{{#is ./slides.length 1}}
+			{{! don't show dots }}
+		{{else}}
+		
+			<div class="navDots
+				{{#if ./carouselOptions.breakOnDesktop}}
+					breakOnDesktop
+				{{/if}}"
+			>
+				{{#each ./slides}}
+					<div class="dot {{#is scope.index 0}}active{{/is}}">
+						{{>navDotsSVG}}
+					</div>
+				{{/each}}
+			</div>
+		{{/if}}
+	{{/if}}
+{{else}} {{! if there are no slides passed into the viewmodel, just show any content passed into the plugin}}
+	<content />
 {{/if}}

--- a/src/donejs-carousel-plugin.stache
+++ b/src/donejs-carousel-plugin.stache
@@ -123,7 +123,7 @@
 					</div>
 				{{/each}}
 			</div>
-		{{/if}}
+		{{/is}}
 	{{/if}}
 {{else}} {{! if there are no slides passed into the viewmodel, just show any content passed into the plugin}}
 	<content />

--- a/src/donejs-carousel-plugin.stache
+++ b/src/donejs-carousel-plugin.stache
@@ -74,7 +74,7 @@
 				{{#if ./carouselOptions.navArrows}}
 					<div class="navArrows">
 
-						<a class="leftArrow arrow" 
+						<a class="leftArrow arrow {{#is ./activeSlideIndex 0}}noMore{{/is}}" 
 							on:click="./arrowClickHandler('left', scope.event)"
 						>
 							<svg role="img" class="iconSvg" title="left nav arrow">
@@ -82,7 +82,7 @@
 							</svg>
 						</a>
 						
-						<a class="rightArrow arrow" 
+						<a class="rightArrow arrow {{#is ./activeSlideIndex ./lastSlideIndex}}noMore{{/is}}" 
 							on:click="./arrowClickHandler('right', scope.event)"
 						>
 							<svg role="img" class="iconSvg" title="right nav arrow">


### PR DESCRIPTION
It looks like I changed a lot but really all I did was: 

1) wrapped the stache logic in {{#if ./slides.length}} with an {{else}} scenario that just displays the content tag. This addressed the no slides scenario.

![noslides](https://user-images.githubusercontent.com/20194649/49660641-1e098e00-fa15-11e8-80c9-c67dd1df7d65.gif)


2) added some logic to add a noMore class to the arrows when there are no more slides to navigate to. I.e. if it's the last slide, the right arrow will have a noMore class added to it and we can style it differently (no hover state and a different color). 

![nomore_arrows](https://user-images.githubusercontent.com/20194649/49660565-e3075a80-fa14-11e8-9171-5268696fec51.gif)